### PR TITLE
Skip dead browsers in Browserlist

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,2 +1,3 @@
 > 1%
 last 2 versions
+not dead


### PR DESCRIPTION
The `last 2 versions` config takes into account IE 11 and IE 10 and `> 1%` doesn’t help, it seems. But getting rid of dead browsers helps to remove ancient flex fallbacks.

```diff
.canvas[data-v-49f15ada] {
  width: 100%;
  height: 100%;
  position: relative;
  background: black;
  padding: 5%;
- display: -webkit-box;
- display: -ms-flexbox;
  display: flex;
- -webkit-box-align: center;
- -ms-flex-align: center;
  align-items: center;
- -webkit-box-pack: center;
- -ms-flex-pack: center;
  justify-content: center;
}
```

But that’s only CSS. Overall JS bundle becomes 770 KB smaller, too (4.91 → 4.14 MB).